### PR TITLE
#12-AuditingFields 추출

### DIFF
--- a/fastcampus-project-board/src/main/java/fastcampus/projectboard/domain/Article.java
+++ b/fastcampus-project-board/src/main/java/fastcampus/projectboard/domain/Article.java
@@ -1,6 +1,5 @@
 package fastcampus.projectboard.domain;
 
-import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -8,7 +7,6 @@ import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -16,12 +14,6 @@ import javax.persistence.Index;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
-
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -35,9 +27,9 @@ import lombok.ToString;
 		@Index(columnList = "createdAt"),
 		@Index(columnList = "createdBy")
 })
-@EntityListeners(AuditingEntityListener.class)
+
 @Entity
-public class Article {
+public class Article extends AuditingFields{
 	
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,11 +44,6 @@ public class Article {
 	@OrderBy("id")
 	@OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
 	private final Set<ArticleComment> articleComments = new LinkedHashSet<>();
-	
-	@CreatedDate @Column(nullable = false) private Date createdAt; //생성일시
-	@CreatedBy @Column(nullable = false, length = 100) private String createdBy; //생성자
-	@LastModifiedDate @Column(nullable = false) private Date modifiedAt; //수정일시
-	@LastModifiedBy @Column(nullable = false, length = 100) private String modifiedBy; //수정자
 	
 	protected Article() {}
 

--- a/fastcampus-project-board/src/main/java/fastcampus/projectboard/domain/ArticleComment.java
+++ b/fastcampus-project-board/src/main/java/fastcampus/projectboard/domain/ArticleComment.java
@@ -1,23 +1,15 @@
 package fastcampus.projectboard.domain;
 
-import java.util.Date;
 import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -30,9 +22,8 @@ import lombok.ToString;
 		@Index(columnList = "createdAt"),
 		@Index(columnList = "createdBy")
 })
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class ArticleComment {
+public class ArticleComment extends AuditingFields {
 	
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,11 +31,6 @@ public class ArticleComment {
 	
 	@Setter @ManyToOne(optional = false) private Article article; //게시글 (id)
 	@Setter @Column(nullable = false, length = 500) private String content; //본문
-	
-	@CreatedDate @Column(nullable = false) private Date createdAt; //생성일시
-	@CreatedBy @Column(nullable = false, length = 100) private String createdBy; //생성자
-	@LastModifiedDate @Column(nullable = false) private Date modifiedAt; //수정일시
-	@LastModifiedBy @Column(nullable = false, length = 100) private String modifiedBy; //수정자
 	
 	protected ArticleComment() {}
 

--- a/fastcampus-project-board/src/main/java/fastcampus/projectboard/domain/AuditingFields.java
+++ b/fastcampus-project-board/src/main/java/fastcampus/projectboard/domain/AuditingFields.java
@@ -1,0 +1,42 @@
+package fastcampus.projectboard.domain;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import lombok.Getter;
+import lombok.ToString;
+
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditingFields {
+	
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+	@CreatedDate 
+	@Column(nullable = false, updatable = false) 
+	private Date createdAt; //생성일시
+	
+	@CreatedBy @Column(nullable = false, updatable = false, length = 100) 
+	private String createdBy; //생성자
+	
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+	@LastModifiedDate 
+	@Column(nullable = false) 
+	private Date modifiedAt; //수정일시
+	
+	@LastModifiedBy 
+	@Column(nullable = false, length = 100) 
+	private String modifiedBy; //수정자
+}


### PR DESCRIPTION
생성자, 생성일시, 수정사, 수정일시 는 반복적으로 엔티티 클래스에 들어가는 요소들이고, 도메인과 직접적인 연관이 없는 요소이므로
추출이 가능하다.

'@MappedSuperclass'를 이용해서 상속방식으로 추출함
그 외, '@DateTimeFormat' 추가 및 JPA 요소 개선