### PR TITLE
게시판 api만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/fastcampus-project-board/build.gradle
+++ b/fastcampus-project-board/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+  	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/fastcampus-project-board/src/main/java/fastcampus/projectboard/repository/ArticleCommentRepository.java
+++ b/fastcampus-project-board/src/main/java/fastcampus/projectboard/repository/ArticleCommentRepository.java
@@ -1,9 +1,11 @@
 package fastcampus.projectboard.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import fastcampus.projectboard.domain.ArticleComment;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long>{
 
 }

--- a/fastcampus-project-board/src/main/java/fastcampus/projectboard/repository/ArticleRepository.java
+++ b/fastcampus-project-board/src/main/java/fastcampus/projectboard/repository/ArticleRepository.java
@@ -1,9 +1,11 @@
 package fastcampus.projectboard.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import fastcampus.projectboard.domain.Article;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long>{
 
 }

--- a/fastcampus-project-board/src/main/resources/application.yaml
+++ b/fastcampus-project-board/src/main/resources/application.yaml
@@ -26,6 +26,10 @@ spring:
       "[hibernate.default_batch_fetch_size]": 100
   h2.console.enabled: false
   sql.init.mode: always
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated
+  
 
 server:
   port: 8188

--- a/fastcampus-project-board/src/test/java/fastcampus/projectboard/controller/DataRestTest.java
+++ b/fastcampus-project-board/src/test/java/fastcampus/projectboard/controller/DataRestTest.java
@@ -1,0 +1,79 @@
+package fastcampus.projectboard.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("Data REST - API 테스트")
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+	private final MockMvc mvc;
+	
+	public DataRestTest(@Autowired MockMvc mvc) {
+		this.mvc = mvc;
+	}
+	
+	
+	@DisplayName("[API] 게시글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+		//Given
+		
+		//When & Then
+		mvc.perform(get("/api/articles"))
+			.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+	
+	
+	@DisplayName("[API] 게시글 단건 조회")
+	@Test
+	void givenNothing_whenRequestingArticle_thenReturnsArticlesJsonResponse() throws Exception {
+		//Given
+		
+		//When & Then
+		mvc.perform(get("/api/articles/1"))
+		.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	
+	@DisplayName("[API] 게시글 -> 댓글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+		//Given
+		
+		//When & Then
+		mvc.perform(get("/api/article/1/articleComments"))
+		.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	
+	@DisplayName("[API] 댓글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+		//Given
+		
+		//When & Then
+		mvc.perform(get("/api/articleComments"))
+		.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	
+	@DisplayName("[API] 댓글 단건 조회")
+	@Test
+	void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+		//Given
+		
+		//When & Then
+		mvc.perform(get("/api/articleComments/1"))
+		.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 api 들의 존재 여부만 체크하게끔 통합테스트 작성